### PR TITLE
Move p46 to new standard of prefixing non-IOC services with the beamline short name

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -27,11 +27,11 @@ services:
   epics-opis:
 
   # daq services ###############################################################
-  daq-rabbitmq:
+  p46-rabbitmq:
     targetRevision: main
-  daq-blueapi:
+  p46-blueapi:
     targetRevision: main
-  daq-nexus:
+  p46-nexus:
     targetRevision: main
 
 ec_services:

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -14,7 +14,7 @@ destination:
   namespace: p46-beamline
 source:
   repoURL: https://github.com/epics-containers/p46-services
-  targetRevision: 2024.11.2
+  targetRevision: main
 
 services:
   # Each item is of the form:
@@ -28,11 +28,8 @@ services:
 
   # daq services ###############################################################
   p46-rabbitmq:
-    targetRevision: main
   p46-blueapi:
-    targetRevision: main
   p46-nexus:
-    targetRevision: main
 
 ec_services:
   # Services which have implemented support for an "enabled" parameter.


### PR DESCRIPTION
To prevent accidental changes to services when the wrong cluster/namespace are in the Kubernetes context, we will move to naming non-IOC services starting with the beamline short name (e.g. ixx) and IOCs with the beamline long name (e.g. BLXXI)

Requires orchestration of the merge with https://github.com/epics-containers/p46-services/pull/3